### PR TITLE
Add Hook for Checking Notebook Parameters Cell (WIP)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,10 @@
   entry: validate_encrypted_secret_name
   language: python
   types: [yaml]
+
+- id: check_notebook_has_parameters_cell
+  name: Check that all notebooks contain a cell tagged with 'parameters'
+  description: Check that all notebooks contain a cell tagged with 'parameters'
+  entry: check_notebook_has_parameters_cell
+  language: python
+  types: [ipynb]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,4 +24,4 @@
   description: Check that all notebooks contain a cell tagged with 'parameters'
   entry: check_notebook_has_parameters_cell
   language: python
-  types: [ipynb]
+  files: (^|/).+\.ipynb$

--- a/pre_commit_hooks/check_notebook_has_parameters_cell.py
+++ b/pre_commit_hooks/check_notebook_has_parameters_cell.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+
+import argparse
+import io
+import sys
+
+import json
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-m',
+        '--multi',
+        '--allow-multiple-documents',
+        action='store_true',
+    )
+
+    parser.add_argument('filenames', nargs='*', help='Filenames to check.')
+    args = parser.parse_args(argv)
+
+    retval = 0
+    for filename in args.filenames:
+
+        with io.open(filename) as f:
+            try:
+                data = json.load(f)
+
+                parameters_cell_exists = False
+
+                for cell in data['cells']:
+                    if 'parameters' in cell['metadata']['tags']:
+                        parameters_cell_exists = True
+
+                if not parameters_cell_exists:
+                    retval = 1
+            except:
+                continue
+
+    return retval
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pre_commit_hooks/check_notebook_has_parameters_cell.py
+++ b/pre_commit_hooks/check_notebook_has_parameters_cell.py
@@ -37,8 +37,10 @@ def main(argv=None):
                         parameters_cell_exists = True
 
                 if not parameters_cell_exists:
+                    print(f'File {filename} does not have a parameters cell')
                     return 1
-            except:
+            except Exception as e:
+                print(f'Exception of file {filename}: {e}')
                 continue
 
     return 0

--- a/pre_commit_hooks/check_notebook_has_parameters_cell.py
+++ b/pre_commit_hooks/check_notebook_has_parameters_cell.py
@@ -19,7 +19,6 @@ def main(argv=None):
     parser.add_argument('filenames', nargs='*', help='Filenames to check.')
     args = parser.parse_args(argv)
 
-    retval = 0
     for filename in args.filenames:
 
         with io.open(filename) as f:
@@ -29,15 +28,20 @@ def main(argv=None):
                 parameters_cell_exists = False
 
                 for cell in data['cells']:
-                    if 'parameters' in cell['metadata']['tags']:
+                    metadata = cell['metadata']
+
+                    if 'tags' not in metadata:
+                        continue
+
+                    if 'parameters' in metadata['tags']:
                         parameters_cell_exists = True
 
                 if not parameters_cell_exists:
-                    retval = 1
+                    return 1
             except:
                 continue
 
-    return retval
+    return 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Relates to viaduct-ai/backlog#769

This pr adds a new pre-commit hook which checks that each `.ipynb` file contains a cell tagged with `"parameters"`. This is what papermill looks for when injecting parameters so every notebook needs to have the parameters tag.